### PR TITLE
Feat: Add Crafting Objects List screen and navigation

### DIFF
--- a/app/src/main/java/com/rabbitv/valheimviki/domain/model/crafting_object/craftingSubCategory.kt
+++ b/app/src/main/java/com/rabbitv/valheimviki/domain/model/crafting_object/craftingSubCategory.kt
@@ -2,8 +2,9 @@ package com.rabbitv.valheimviki.domain.model.crafting_object
 
 enum class CraftingSubCategory {
     CRAFTING_STATION,
-    CRAFTING_UPGRADER,
-    CRAFTING_UPGRADER_FOOD,
     FOOD_CRAFTING,
     SMELTING_CRAFTING,
+    REFINING_STATION,
+    CRAFTING_UPGRADER,
+    CRAFTING_UPGRADER_FOOD,
 }

--- a/app/src/main/java/com/rabbitv/valheimviki/navigation/Screen.kt
+++ b/app/src/main/java/com/rabbitv/valheimviki/navigation/Screen.kt
@@ -41,6 +41,9 @@ sealed class Screen() {
 	data object MeadList : Screen()
 
 	@Serializable
+	data object CraftingObjectsList : Screen()
+
+	@Serializable
 	data object ToolList : Screen()
 
 	@Serializable

--- a/app/src/main/java/com/rabbitv/valheimviki/navigation/ValheimVikiApp.kt
+++ b/app/src/main/java/com/rabbitv/valheimviki/navigation/ValheimVikiApp.kt
@@ -51,6 +51,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
+import com.composables.icons.lucide.Anvil
 import com.composables.icons.lucide.Cuboid
 import com.composables.icons.lucide.FlaskRound
 import com.composables.icons.lucide.Gavel
@@ -75,6 +76,7 @@ import com.rabbitv.valheimviki.presentation.building_material.BuildingMaterialLi
 import com.rabbitv.valheimviki.presentation.building_material.viewmodel.BuildingMaterialListViewModel
 import com.rabbitv.valheimviki.presentation.components.DrawerItem
 import com.rabbitv.valheimviki.presentation.components.NavigationDrawer
+import com.rabbitv.valheimviki.presentation.crafting.CraftingListScreen
 import com.rabbitv.valheimviki.presentation.creatures.bosses.BossScreen
 import com.rabbitv.valheimviki.presentation.creatures.mini_bosses.MiniBossScreen
 import com.rabbitv.valheimviki.presentation.creatures.mob_list.MobListScreen
@@ -369,6 +371,16 @@ fun ValheimNavGraph(
 			)
 		}
 
+		composable<Screen.CraftingObjectsList> {
+			CraftingListScreen(
+				modifier = Modifier.padding(10.dp),
+				onItemClick = { _, _ ->
+					// TODO: Implement navigation
+				},
+				paddingValues = innerPadding,
+			)
+		}
+
 		composable<Screen.ToolList> {
 			ToolListScreen(
 				modifier = Modifier.padding(10.dp),
@@ -646,6 +658,9 @@ fun rememberDrawerItems(): List<DrawerItem> {
 	val meadsLabel = stringResource(R.string.meads)
 	val meadsDesc = stringResource(R.string.mead_section)
 
+	val craftingObjectsLabel = stringResource(R.string.crafting_stations)
+	val craftingObjectsDesc = stringResource(R.string.crafting_stations_section)
+
 	val toolsLabel = stringResource(R.string.tools)
 	val toolsDesc = stringResource(R.string.tools_section)
 
@@ -674,6 +689,7 @@ fun rememberDrawerItems(): List<DrawerItem> {
 	val shieldIcon = Lucide.Shield
 	val utensilsIcon = Lucide.Utensils
 	val flaskIcon = Lucide.FlaskRound
+	val anvilIcon = Lucide.Anvil
 	val gavelIcon = Lucide.Gavel
 	val cuboidIcon = Lucide.Cuboid
 	val houseIcon = Lucide.House
@@ -740,6 +756,13 @@ fun rememberDrawerItems(): List<DrawerItem> {
 				contentDescription = meadsDesc,
 				screen = Screen.MeadList
 			),
+			// CraftingObjects
+			DrawerItem(
+				icon = anvilIcon,
+				label = craftingObjectsLabel,
+				contentDescription = craftingObjectsDesc,
+				screen = Screen.CraftingObjectsList
+			),
 			// Tools
 			DrawerItem(
 				icon = gavelIcon,
@@ -790,7 +813,7 @@ fun NavDestination.shouldShowTopBar(): Boolean {
 	val route = this.route ?: return false
 	return listOf(
 		"BiomeList", "BossList", "MiniBossList", "MobList",
-		"WeaponList", "ArmorList", "FoodList", "MeadList", "ToolList",
+		"WeaponList", "ArmorList", "FoodList", "MeadList","CraftingObjectsList" ,"ToolList",
 		"MaterialCategory", "BuildingMaterialCategory",
 		"OreDeposit", "Tree", "PointOfInterest"
 	).any { route.contains(it, ignoreCase = true) }

--- a/app/src/main/java/com/rabbitv/valheimviki/presentation/components/NavigationDrawer.kt
+++ b/app/src/main/java/com/rabbitv/valheimviki/presentation/components/NavigationDrawer.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import com.composables.icons.lucide.Anvil
 import com.composables.icons.lucide.Cuboid
 import com.composables.icons.lucide.FlaskRound
 import com.composables.icons.lucide.Gavel
@@ -278,6 +279,13 @@ private fun PreviewNavigationDrawer() {
 			label = "Mead",
 			contentDescription = "Mead section",
 			screen = Screen.MeadList
+		),
+
+		DrawerItem(
+			icon = Lucide.Anvil,
+			label = "Crafting Stations",
+			contentDescription = "Crafting Station section",
+			screen = Screen.CraftingObjectsList
 		),
 		DrawerItem(
 			icon = Lucide.Gavel,

--- a/app/src/main/java/com/rabbitv/valheimviki/presentation/crafting/CraftingListScreen.kt
+++ b/app/src/main/java/com/rabbitv/valheimviki/presentation/crafting/CraftingListScreen.kt
@@ -1,0 +1,253 @@
+package com.rabbitv.valheimviki.presentation.crafting
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.composables.icons.lucide.Apple
+import com.composables.icons.lucide.Axe
+import com.composables.icons.lucide.ChefHat
+import com.composables.icons.lucide.Cog
+import com.composables.icons.lucide.Flame
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.TrendingUp
+import com.composables.icons.lucide.Wrench
+import com.rabbitv.valheimviki.domain.model.armor.Armor
+import com.rabbitv.valheimviki.domain.model.armor.ArmorSubCategory
+import com.rabbitv.valheimviki.domain.model.crafting_object.CraftingObject
+import com.rabbitv.valheimviki.domain.model.crafting_object.CraftingSubCategory
+import com.rabbitv.valheimviki.domain.model.ui_state.category_state.UiCategoryState
+import com.rabbitv.valheimviki.presentation.armor.viewmodel.ArmorListViewModel
+import com.rabbitv.valheimviki.presentation.components.EmptyScreen
+import com.rabbitv.valheimviki.presentation.components.ListContent
+import com.rabbitv.valheimviki.presentation.components.chip.ChipData
+import com.rabbitv.valheimviki.presentation.components.chip.CustomElevatedFilterChip
+import com.rabbitv.valheimviki.presentation.components.chip.SearchFilterBar
+import com.rabbitv.valheimviki.presentation.components.shimmering_effect.ShimmerListEffect
+import com.rabbitv.valheimviki.presentation.crafting.viewmodel.CraftingListViewModel
+import com.rabbitv.valheimviki.ui.theme.BODY_CONTENT_PADDING
+import com.rabbitv.valheimviki.ui.theme.ValheimVikiAppTheme
+import com.rabbitv.valheimviki.utils.FakeData
+
+
+data class CraftingChip(
+    override val option: CraftingSubCategory,
+    override val icon: ImageVector,
+    val secondIcon: ImageVector? = null,
+    override val label: String
+) : ChipData<CraftingSubCategory>
+
+@Composable
+fun CraftingListScreen(
+    modifier: Modifier = Modifier,
+    onItemClick: (armorId :String, _:Int) -> Unit,
+    paddingValues: PaddingValues,
+    viewModel: CraftingListViewModel = hiltViewModel()
+) {
+    val craftingObjectListUiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val onChipSelected = { chip: CraftingSubCategory? -> viewModel.onChipSelected(chip) }
+    CraftingListStateRenderer(
+        craftingObjectListUiState = craftingObjectListUiState,
+        onChipSelected = onChipSelected,
+        paddingValues = paddingValues,
+        modifier = modifier,
+        onItemClick = onItemClick
+    )
+
+}
+
+@Composable
+fun CraftingListStateRenderer(
+    craftingObjectListUiState: UiCategoryState<CraftingSubCategory?, CraftingObject>,
+    onChipSelected: (CraftingSubCategory?) -> Unit,
+    paddingValues: PaddingValues,
+    modifier: Modifier,
+    onItemClick:(armorId :String, _:Int) -> Unit,
+) {
+    Surface(
+        color = Color.Transparent,
+        modifier = Modifier
+            .testTag("WeaponListSurface")
+            .fillMaxSize()
+            .padding(paddingValues)
+            .then(modifier)
+    ) {
+
+        ArmorListDisplay(
+            craftingObjectListUiState = craftingObjectListUiState,
+            onChipSelected = onChipSelected,
+            onItemClick = onItemClick
+        )
+    }
+}
+
+
+
+@Composable
+fun ArmorListDisplay(
+    craftingObjectListUiState: UiCategoryState<CraftingSubCategory?, CraftingObject>,
+    onChipSelected: (CraftingSubCategory?) -> Unit,
+    onItemClick: (armorId: String, _: Int) -> Unit
+) {
+
+
+    val lazyListState = rememberLazyListState()
+
+
+
+
+    Column(
+        horizontalAlignment = Alignment.Start
+    ) {
+        SearchFilterBar(
+            chips = getChipsForCategory(),
+            selectedOption = craftingObjectListUiState.selectedCategory,
+            onSelectedChange = { _, subCategory ->
+                if (craftingObjectListUiState.selectedCategory == subCategory) {
+                    onChipSelected(null)
+                } else {
+                    onChipSelected(subCategory)
+                }
+            },
+            modifier = Modifier,
+        )
+        Spacer(Modifier.padding(horizontal = BODY_CONTENT_PADDING.dp, vertical = 5.dp))
+        when (val state = craftingObjectListUiState) {
+            is UiCategoryState.Error<CraftingSubCategory?> -> EmptyScreen(errorMessage = state.message.toString())
+            is UiCategoryState.Loading<CraftingSubCategory?> -> ShimmerListEffect()
+            is UiCategoryState.Success<CraftingSubCategory?, CraftingObject> -> ListContent(
+                items = state.list,
+                clickToNavigate = onItemClick,
+                lazyListState = lazyListState,
+                subCategoryNumber = 0,
+                imageScale = ContentScale.Fit,
+                horizontalPadding = 0.dp
+            )
+        }
+    }
+}
+
+
+@Composable
+private fun getChipsForCategory(): List<CraftingChip> {
+    return listOf(
+        CraftingChip(
+            CraftingSubCategory.CRAFTING_STATION,
+            Lucide.Wrench,
+           label = "Crafting Stations"
+        ),
+        CraftingChip(
+            CraftingSubCategory.FOOD_CRAFTING,
+            Lucide.ChefHat,
+            label =  "Food crafting Stations"
+        ),
+        CraftingChip(
+            CraftingSubCategory.SMELTING_CRAFTING,
+            Lucide.Flame,
+            label = "Smelting Stations"
+        ),
+        CraftingChip(
+            CraftingSubCategory.REFINING_STATION,
+            Lucide.Cog,
+            label = "Refinery Stations"
+        ),
+        CraftingChip(
+            CraftingSubCategory.CRAFTING_UPGRADER,
+            Lucide.TrendingUp,
+            label = "Crafting Upgraders"
+        ),
+        CraftingChip(
+            CraftingSubCategory.CRAFTING_UPGRADER_FOOD,
+            Lucide.Apple,
+            Lucide.TrendingUp,
+            label =  "Crafting Upgraders For Food Ftation"
+        ),
+    )
+}
+
+
+@Preview("SingleChoiceChipPreview")
+@Composable
+fun PreviewSingleChoiceChip() {
+    ValheimVikiAppTheme {
+        SearchFilterBar(
+            onSelectedChange = { i, s -> {} },
+            modifier = Modifier,
+            selectedOption = CraftingSubCategory.CRAFTING_STATION,
+            chips = getChipsForCategory()
+        )
+    }
+}
+
+
+@Preview("CustomElevatedFilterChipSelectedPreview")
+@Composable
+fun PreviewCustomElevatedFilterChipSelected() {
+    ValheimVikiAppTheme {
+        CustomElevatedFilterChip(
+
+            index = 0,
+            selectedChipIndex = 0,
+            onSelectedChange = { i, s -> {} },
+            label = "Axes",
+            icon = Lucide.Axe,
+            option = ArmorSubCategory.CAPE,
+        )
+    }
+
+}
+
+@Preview("CustomElevatedFilterChipNotSelectedPreview")
+@Composable
+fun PreviewCustomElevatedFilterChipNotSelected() {
+    ValheimVikiAppTheme {
+        CustomElevatedFilterChip(
+            index = 1,
+            selectedChipIndex = 0,
+            onSelectedChange = { i, s -> {} },
+            label = "Axes",
+            icon = Lucide.Axe,
+            option = ArmorSubCategory.CAPE,
+        )
+    }
+
+}
+
+
+@Preview(name = "WeaponListStateRendererPreview")
+@Composable
+fun PreviewWeaponListStateRenderer() {
+    ValheimVikiAppTheme {
+        CraftingListStateRenderer(
+            craftingObjectListUiState = UiCategoryState.Success(
+                selectedCategory = CraftingSubCategory.CRAFTING_STATION,
+                list = FakeData.fakeCraftingObjectList()
+            ),
+            paddingValues = PaddingValues(),
+            modifier = Modifier,
+            onChipSelected = {},
+            onItemClick = {_,_ -> {}}
+        )
+    }
+}
+
+
+
+

--- a/app/src/main/java/com/rabbitv/valheimviki/presentation/crafting/viewmodel/CraftingListViewModel.kt
+++ b/app/src/main/java/com/rabbitv/valheimviki/presentation/crafting/viewmodel/CraftingListViewModel.kt
@@ -1,0 +1,97 @@
+package com.rabbitv.valheimviki.presentation.crafting.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.rabbitv.valheimviki.domain.model.armor.Armor
+import com.rabbitv.valheimviki.domain.model.armor.ArmorSubCategory
+import com.rabbitv.valheimviki.domain.model.crafting_object.CraftingObject
+import com.rabbitv.valheimviki.domain.model.crafting_object.CraftingSubCategory
+import com.rabbitv.valheimviki.domain.model.ui_state.category_state.UiCategoryState
+import com.rabbitv.valheimviki.domain.repository.ArmorRepository
+import com.rabbitv.valheimviki.domain.repository.NetworkConnectivity
+import com.rabbitv.valheimviki.domain.use_cases.crafting_object.CraftingObjectUseCases
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@Suppress("UNCHECKED_CAST")
+@HiltViewModel
+class CraftingListViewModel @Inject constructor(
+    private val craftingObjectUseCases: CraftingObjectUseCases,
+    private val connectivityObserver: NetworkConnectivity,
+) : ViewModel() {
+
+
+    private val _selectedChip = MutableStateFlow<CraftingSubCategory?>(null)
+
+
+    private val _craftingObjects: StateFlow<List<CraftingObject>> =
+        combine(
+            craftingObjectUseCases.getLocalCraftingObjectsUseCase(),
+            _selectedChip,
+        ) { allCraftingObjects, chip ->
+            val filtered = allCraftingObjects.filter { chip == null || it.subCategory == chip.toString() }
+
+            if (chip == null) {
+                filtered.sortedBy { it.name }
+            } else {
+                filtered.sortedBy { it.order }
+            }
+        }.flowOn(Dispatchers.Default)
+            .stateIn(viewModelScope, SharingStarted.Companion.WhileSubscribed(5000), emptyList())
+
+    val uiState: StateFlow<UiCategoryState<CraftingSubCategory?, CraftingObject>> = combine(
+        _craftingObjects,
+        _selectedChip,
+        connectivityObserver.isConnected.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Companion.WhileSubscribed(5000),
+            initialValue = false
+        )
+    ) { craftingObjects, selectedChip, isConnected ->
+        if (isConnected) {
+            if (craftingObjects.isNotEmpty()) {
+                UiCategoryState.Success(selectedChip, craftingObjects)
+            } else {
+                UiCategoryState.Loading(selectedChip)
+            }
+        } else {
+            if (craftingObjects.isNotEmpty()) {
+                UiCategoryState.Success(selectedChip, craftingObjects)
+            } else {
+                UiCategoryState.Error(
+                    selectedChip,
+                    "No internet connection and no local data available. Try to connect to the internet again.",
+                )
+            }
+        }
+    }.onStart {
+        emit(UiCategoryState.Loading(_selectedChip.value))
+    }.catch { e ->
+        Log.e("CraftingObjectListVM", "Error in uiState flow", e)
+        emit(
+            UiCategoryState.Error(
+                _selectedChip.value,
+                e.message ?: "An unknown error occurred"
+            )
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Companion.WhileSubscribed(5000),
+        initialValue = UiCategoryState.Loading(_selectedChip.value)
+    )
+
+
+    fun onChipSelected(chip: CraftingSubCategory?) {
+        _selectedChip.value = chip
+    }
+}

--- a/app/src/main/java/com/rabbitv/valheimviki/utils/FakeData.kt
+++ b/app/src/main/java/com/rabbitv/valheimviki/utils/FakeData.kt
@@ -10,6 +10,7 @@ import com.composables.icons.lucide.Shield
 import com.rabbitv.valheimviki.domain.model.armor.Armor
 import com.rabbitv.valheimviki.domain.model.armor.UpgradeArmorInfo
 import com.rabbitv.valheimviki.domain.model.biome.Biome
+import com.rabbitv.valheimviki.domain.model.crafting_object.CraftingObject
 import com.rabbitv.valheimviki.domain.model.creature.Creature
 import com.rabbitv.valheimviki.domain.model.creature.npc.NPC
 import com.rabbitv.valheimviki.domain.model.material.Material
@@ -23,7 +24,77 @@ import com.rabbitv.valheimviki.presentation.detail.creature.npc.model.NpcDetailU
 
 
 object FakeData {
+    fun fakeCraftingObjectList(count: Int = 5): List<CraftingObject> {
+        val baseCraftingObjects = listOf(
+            CraftingObject(
+                id = "workbench",
+                imageUrl = "https://picsum.photos/200/200?random=1",
+                category = "Crafting",
+                subCategory = "CRAFTING_STATION",
+                name = "Workbench",
+                description = "A basic crafting station for creating simple tools and weapons.",
+                order = 1
+            ),
+            CraftingObject(
+                id = "cauldron",
+                imageUrl = "https://picsum.photos/200/200?random=2",
+                category = "Crafting",
+                subCategory = "FOOD_CRAFTING",
+                name = "Cauldron",
+                description = "A large iron pot used for cooking hearty meals and brewing potions.",
+                order = 2
+            ),
+            CraftingObject(
+                id = "smelter",
+                imageUrl = "https://picsum.photos/200/200?random=3",
+                category = "Crafting",
+                subCategory = "SMELTING_CRAFTING",
+                name = "Smelter",
+                description = "A furnace for melting ores into valuable metal ingots.",
+                order = 3
+            ),
+            CraftingObject(
+                id = "stonecutter",
+                imageUrl = "https://picsum.photos/200/200?random=4",
+                category = "Crafting",
+                subCategory = "REFINING_STATION",
+                name = "Stonecutter",
+                description = "A precision tool for shaping stone blocks and decorative items.",
+                order = 4
+            ),
+            CraftingObject(
+                id = "forge",
+                imageUrl = "https://picsum.photos/200/200?random=5",
+                category = "Crafting",
+                subCategory = "CRAFTING_UPGRADER",
+                name = "Forge",
+                description = "An advanced smithing station for upgrading weapons and armor.",
+                order = 5
+            ),
+            CraftingObject(
+                id = "spice_rack",
+                imageUrl = "https://picsum.photos/200/200?random=6",
+                category = "Crafting",
+                subCategory = "CRAFTING_UPGRADER_FOOD",
+                name = "Spice Rack",
+                description = "A collection of rare spices that enhance the quality of cooked meals.",
+                order = 6
+            )
+        )
 
+        return if (count <= baseCraftingObjects.size) {
+            baseCraftingObjects.take(count)
+        } else {
+            baseCraftingObjects + List(count - baseCraftingObjects.size) { idx ->
+                val baseIndex = idx % baseCraftingObjects.size
+                val base = baseCraftingObjects[baseIndex]
+                base.copy(
+                    id = "${base.id}_${idx + baseCraftingObjects.size}",
+                    order = idx + baseCraftingObjects.size + 1
+                )
+            }
+        }
+    }
     fun fakeArmorList(count: Int = 10): List<Armor> {
         val baseArmor = Armor(
             id = "iron_helmet",

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,4 +48,6 @@
     <string name="mead_section">Mead section</string>
     <string name="food_section">Food section</string>
     <string name="armor_section">Armor section</string>
+    <string name="crafting_stations_section">Crafting Stations section</string>
+    <string name="crafting_stations">Crafting Stations</string>
 </resources>


### PR DESCRIPTION
- Added `CraftingObjectsList` to `Screen.kt` for navigation.
- Included "Crafting Stations" in `NavigationDrawer.kt` using `Lucide.Anvil` icon.
- Updated `CraftingSubCategory.kt` to reorder subcategories.
- Created `CraftingListViewModel.kt` to manage UI state and data fetching for crafting objects, including filtering by subcategory.
- Implemented `CraftingListScreen.kt` to display crafting objects with filter chips for subcategories (Crafting Station, Food Crafting, Smelting, Refining, Crafting Upgrader, Crafting Upgrader Food).
  - Uses `ListContent` for displaying items and `SearchFilterBar` for filtering.
  - Includes shimmer loading effect and error handling.
- Integrated `CraftingListScreen` into `ValheimVikiApp.kt` navigation graph.
- Added `fakeCraftingObjectList` in `FakeData.kt` for preview and testing.
- Added string resources for "Crafting Stations" and its section description.